### PR TITLE
Add SessionManagement PowerShell module and lifecycle tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,33 @@ wsl --install
 Then open a WSL terminal and follow the Linux instructions.
 
 </details>
+### PowerShell SessionManagement Module (Developer)
+
+For session lifecycle development and validation, a PowerShell module is available at `powershell/SessionManagement`.
+
+```powershell
+# Import module
+Import-Module .\powershell\SessionManagement\SessionManagement.psd1 -Force
+
+# Run the included example lifecycle
+.\powershell\SessionManagement\examples\Run-Session.ps1
+```
+
+The module exposes `New-SessionManager`, which builds a class-based lifecycle runner with four phases:
+- `SessionHandshake`
+- `ActivationRecord`
+- `Cleanup`
+- `Verify`
+
+Run tests:
+
+```powershell
+# Unit tests
+Invoke-Pester -Script .\powershell\SessionManagement\tests\SessionManager.Tests.ps1
+
+# Integration tests
+Invoke-Pester -Script .\powershell\SessionManagement\tests\SessionManager.Integration.Tests.ps1
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,59 @@ wsl --install
 
 Then open a WSL terminal and follow the Linux instructions.
 
+To build from PowerShell after WSL is configured, replace `<DISTRO>` with your WSL distribution name and update the project path if needed:
+
+```powershell
+wsl -d <DISTRO> --exec /bin/bash -lc "cd /mnt/c/Users/<USER>/tr4mpass && make"
+```
+
+If the target is already current, `make` reports `Nothing to be done for 'all'`.
+
+The build creates:
+
+- `tr4mpass` at the project root
+- `*.o` object files under `src/`
+
+Verify the executable without starting device operations:
+
+```powershell
+wsl -d <DISTRO> --exec /bin/bash -lc "cd /mnt/c/Users/<USER>/tr4mpass && ./tr4mpass --help"
+```
+
+Run a non-invasive startup/configuration check:
+
+```powershell
+wsl -d <DISTRO> --exec /bin/bash -lc "cd /mnt/c/Users/<USER>/tr4mpass && ./tr4mpass --dry-run --verbose"
+```
+
+For USB device detection from WSL on Windows, install `usbipd-win` on the Windows host and USB tools inside WSL:
+
+```powershell
+winget install --id dorssel.usbipd-win --accept-package-agreements --accept-source-agreements
+wsl -d <DISTRO> --exec /bin/bash -lc "sudo apt-get update && sudo apt-get install -y usbutils usbip"
+```
+
+List Windows USB devices:
+
+```powershell
+& 'C:\Program Files\usbipd-win\usbipd.exe' list
+```
+
+Bind and attach the target USB device from an Administrator PowerShell, replacing `<BUSID>` with the bus ID shown by `usbipd list`:
+
+```powershell
+& 'C:\Program Files\usbipd-win\usbipd.exe' bind --busid <BUSID> --force
+& 'C:\Program Files\usbipd-win\usbipd.exe' attach --wsl --busid <BUSID>
+```
+
+Confirm WSL can see the USB device:
+
+```powershell
+wsl -d <DISTRO> --exec /bin/bash -lc "lsusb"
+```
+
 </details>
+
 ### PowerShell SessionManagement Module (Developer)
 
 For session lifecycle development and validation, a PowerShell module is available at `powershell/SessionManagement`.

--- a/powershell/SessionManagement/Classes/SessionManager.ps1
+++ b/powershell/SessionManagement/Classes/SessionManager.ps1
@@ -1,0 +1,172 @@
+class SessionPhaseResult {
+    [string]$Name
+    [bool]$Succeeded
+    [datetime]$StartedAt
+    [datetime]$CompletedAt
+    [string]$ErrorMessage
+
+    SessionPhaseResult([string]$name) {
+        $this.Name = $name
+        $this.Succeeded = $false
+    }
+}
+
+class SessionExecutionResult {
+    [string]$SessionId
+    [bool]$Succeeded
+    [datetime]$StartedAt
+    [datetime]$CompletedAt
+    [hashtable]$ActivationRecord
+    [SessionPhaseResult[]]$Phases
+
+    SessionExecutionResult() {
+        $this.Phases = @()
+        $this.Succeeded = $false
+    }
+}
+
+class SessionManager {
+    [string]$SessionId
+    [hashtable]$Context
+    [hashtable]$ActivationRecord
+    hidden [System.Collections.ArrayList]$PhaseHistory
+    hidden [scriptblock]$HandshakeAction
+    hidden [scriptblock]$ActivationAction
+    hidden [scriptblock]$CleanupAction
+    hidden [scriptblock]$VerifyAction
+
+    SessionManager(
+        [string]$sessionId,
+        [scriptblock]$handshakeAction,
+        [scriptblock]$activationAction,
+        [scriptblock]$cleanupAction,
+        [scriptblock]$verifyAction
+    ) {
+        if ([string]::IsNullOrWhiteSpace($sessionId)) {
+            throw 'SessionId is required.'
+        }
+
+        foreach ($pair in @(
+            @{ Name = 'handshakeAction'; Value = $handshakeAction },
+            @{ Name = 'activationAction'; Value = $activationAction },
+            @{ Name = 'cleanupAction'; Value = $cleanupAction },
+            @{ Name = 'verifyAction'; Value = $verifyAction }
+        )) {
+            if ($null -eq $pair.Value) {
+                throw "$($pair.Name) cannot be null."
+            }
+        }
+
+        $this.SessionId = $sessionId
+        $this.Context = @{
+            SessionId      = $sessionId
+            HandshakeData  = @{}
+            CleanupDetails = @{}
+            Verification   = @{}
+        }
+        $this.ActivationRecord = @{}
+        $this.PhaseHistory = [System.Collections.ArrayList]::new()
+        $this.HandshakeAction = $handshakeAction
+        $this.ActivationAction = $activationAction
+        $this.CleanupAction = $cleanupAction
+        $this.VerifyAction = $verifyAction
+    }
+
+    [SessionExecutionResult] Run() {
+        $execution = [SessionExecutionResult]::new()
+        $execution.SessionId = $this.SessionId
+        $execution.StartedAt = [datetime]::UtcNow
+
+        try {
+            [void]$this.InvokePhase('SessionHandshake', $this.HandshakeAction)
+            [void]$this.InvokePhase('ActivationRecord', $this.ActivationAction)
+        }
+        catch {
+            $this.Context['Failure'] = @{
+                Phase = $this.GetLastPhaseName()
+                Error = $_.Exception.Message
+            }
+        }
+        finally {
+            try {
+                [void]$this.InvokePhase('Cleanup', $this.CleanupAction)
+            }
+            catch {
+                $this.Context['CleanupFailure'] = $_.Exception.Message
+            }
+
+            try {
+                [void]$this.InvokePhase('Verify', $this.VerifyAction)
+            }
+            catch {
+                $this.Context['VerificationFailure'] = $_.Exception.Message
+            }
+        }
+
+        $phaseResults = @($this.PhaseHistory.ToArray())
+        $execution.Phases = $phaseResults
+        $execution.ActivationRecord = $this.CloneHashtable($this.ActivationRecord)
+        $execution.CompletedAt = [datetime]::UtcNow
+        $execution.Succeeded = $this.DetermineOverallSuccess($phaseResults)
+        return $execution
+    }
+
+    hidden [SessionPhaseResult] InvokePhase([string]$name, [scriptblock]$action) {
+        $phase = [SessionPhaseResult]::new($name)
+        $phase.StartedAt = [datetime]::UtcNow
+        try {
+            $null = & $action $this.Context $this.ActivationRecord
+            $phase.Succeeded = $true
+            return $phase
+        }
+        catch {
+            $phase.ErrorMessage = $_.Exception.Message
+            throw
+        }
+        finally {
+            $phase.CompletedAt = [datetime]::UtcNow
+            [void]$this.PhaseHistory.Add($phase)
+        }
+    }
+
+    hidden [string] GetLastPhaseName() {
+        if ($this.PhaseHistory.Count -eq 0) {
+            return ''
+        }
+
+        return $this.PhaseHistory[$this.PhaseHistory.Count - 1].Name
+    }
+
+    hidden [bool] DetermineOverallSuccess([SessionPhaseResult[]]$phaseResults) {
+        if ($null -eq $phaseResults -or $phaseResults.Count -eq 0) {
+            return $false
+        }
+
+        $required = @('SessionHandshake', 'ActivationRecord', 'Cleanup', 'Verify')
+        foreach ($name in $required) {
+            $matching = @($phaseResults | Where-Object { $_.Name -eq $name })
+            if ($matching.Count -eq 0) {
+                return $false
+            }
+
+            if (-not $matching[0].Succeeded) {
+                return $false
+            }
+        }
+
+        return $true
+    }
+
+    hidden [hashtable] CloneHashtable([hashtable]$source) {
+        $copy = @{}
+        if ($null -eq $source) {
+            return $copy
+        }
+
+        foreach ($key in $source.Keys) {
+            $copy[$key] = $source[$key]
+        }
+
+        return $copy
+    }
+}

--- a/powershell/SessionManagement/Public/New-SessionManager.ps1
+++ b/powershell/SessionManagement/Public/New-SessionManager.ps1
@@ -1,0 +1,32 @@
+function New-SessionManager {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SessionId,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [scriptblock]$HandshakeAction,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [scriptblock]$ActivationAction,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [scriptblock]$CleanupAction,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [scriptblock]$VerifyAction
+    )
+
+    return [SessionManager]::new(
+        $SessionId,
+        $HandshakeAction,
+        $ActivationAction,
+        $CleanupAction,
+        $VerifyAction
+    )
+}

--- a/powershell/SessionManagement/SessionManagement.psd1
+++ b/powershell/SessionManagement/SessionManagement.psd1
@@ -1,0 +1,14 @@
+@{
+    RootModule        = 'SessionManagement.psm1'
+    ModuleVersion     = '1.0.0'
+    GUID              = 'dca2d036-f71d-410f-a907-e03d9ce26315'
+    Author            = 'tr4mpass contributors'
+    CompanyName       = 'Community'
+    Copyright         = '(c) tr4mpass contributors'
+    Description       = 'Session lifecycle module with handshake, activation, cleanup, and verification phases.'
+    PowerShellVersion = '5.1'
+    FunctionsToExport = @('New-SessionManager')
+    CmdletsToExport   = @()
+    VariablesToExport = @()
+    AliasesToExport   = @()
+}

--- a/powershell/SessionManagement/SessionManagement.psm1
+++ b/powershell/SessionManagement/SessionManagement.psm1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = 'Stop'
+
+$moduleRoot = Split-Path -Path $PSCommandPath -Parent
+
+. (Join-Path -Path $moduleRoot -ChildPath 'Classes/SessionManager.ps1')
+. (Join-Path -Path $moduleRoot -ChildPath 'Public/New-SessionManager.ps1')
+
+Export-ModuleMember -Function 'New-SessionManager'

--- a/powershell/SessionManagement/examples/Run-Session.ps1
+++ b/powershell/SessionManagement/examples/Run-Session.ps1
@@ -1,0 +1,35 @@
+Import-Module "$PSScriptRoot/../SessionManagement.psd1" -Force
+
+$manager = New-SessionManager `
+    -SessionId 'session-001' `
+    -HandshakeAction {
+        param($context, $activationRecord)
+        $context.HandshakeData.Protocol = 'drmHandshake'
+        $context.HandshakeData.Version = '1.0'
+    } `
+    -ActivationAction {
+        param($context, $activationRecord)
+        $activationRecord.SessionId = $context.SessionId
+        $activationRecord.Status = 'Active'
+        $activationRecord.StartedAt = [datetime]::UtcNow
+    } `
+    -CleanupAction {
+        param($context, $activationRecord)
+        $context.CleanupDetails.DisposedTempFiles = 0
+        $context.CleanupDetails.StaleHandlesClosed = 0
+    } `
+    -VerifyAction {
+        param($context, $activationRecord)
+        if (-not $context.HandshakeData.Protocol) {
+            throw 'Handshake data missing.'
+        }
+
+        if (-not $activationRecord.Status -or $activationRecord.Status -ne 'Active') {
+            throw 'Activation record not active.'
+        }
+
+        $context.Verification.Result = 'Passed'
+    }
+
+$result = $manager.Run()
+$result

--- a/powershell/SessionManagement/tests/SessionManager.Integration.Tests.ps1
+++ b/powershell/SessionManagement/tests/SessionManager.Integration.Tests.ps1
@@ -1,0 +1,125 @@
+$moduleManifest = Join-Path -Path $PSScriptRoot -ChildPath '..\SessionManagement.psd1'
+Import-Module $moduleManifest -Force
+
+Describe 'SessionManager integration lifecycle' {
+    It 'executes handshake, activation, cleanup, and verify with real artifacts' {
+        $runId = [guid]::NewGuid().ToString('N')
+        $workDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ("session-manager-it-" + $runId)
+        New-Item -Path $workDir -ItemType Directory -Force | Out-Null
+
+        try {
+            $staleFile = Join-Path -Path $workDir -ChildPath 'stale.tmp'
+            New-Item -Path $staleFile -ItemType File -Force | Out-Null
+
+            $handshakeFile = Join-Path -Path $workDir -ChildPath 'handshake.json'
+            $activationFile = Join-Path -Path $workDir -ChildPath 'activation.json'
+            $cleanupFile = Join-Path -Path $workDir -ChildPath 'cleanup.log'
+
+            $manager = New-SessionManager `
+                -SessionId 'integration-001' `
+                -HandshakeAction {
+                    param($context, $activationRecord)
+                    $context.HandshakeData.File = $handshakeFile
+                    $context.HandshakeData.Protocol = 'drmHandshake'
+                    @{ protocol = 'drmHandshake'; status = 'ok' } | ConvertTo-Json | Set-Content -Path $handshakeFile -Encoding UTF8
+                } `
+                -ActivationAction {
+                    param($context, $activationRecord)
+                    $activationRecord.SessionId = $context.SessionId
+                    $activationRecord.Status = 'Active'
+                    $activationRecord.Path = $activationFile
+                    $activationRecord | ConvertTo-Json | Set-Content -Path $activationFile -Encoding UTF8
+                } `
+                -CleanupAction {
+                    param($context, $activationRecord)
+                    if (Test-Path -Path $staleFile) {
+                        Remove-Item -Path $staleFile -Force
+                    }
+
+                    "cleanup complete for $($context.SessionId)" | Set-Content -Path $cleanupFile -Encoding UTF8
+                    $context.CleanupDetails.Path = $cleanupFile
+                } `
+                -VerifyAction {
+                    param($context, $activationRecord)
+                    if (-not (Test-Path -Path $context.HandshakeData.File)) { throw 'Handshake artifact missing.' }
+                    if (-not (Test-Path -Path $activationRecord.Path)) { throw 'Activation artifact missing.' }
+                    if (-not (Test-Path -Path $context.CleanupDetails.Path)) { throw 'Cleanup artifact missing.' }
+                    if (Test-Path -Path $staleFile) { throw 'Stale file was not removed.' }
+
+                    $activation = Get-Content -Path $activationRecord.Path -Raw | ConvertFrom-Json
+                    if ($activation.Status -ne 'Active') { throw 'Activation status invalid.' }
+                }
+
+            $result = $manager.Run()
+
+            $result.Succeeded | Should Be $true
+            $result.Phases.Count | Should Be 4
+            $result.Phases[0].Name | Should Be 'SessionHandshake'
+            $result.Phases[1].Name | Should Be 'ActivationRecord'
+            $result.Phases[2].Name | Should Be 'Cleanup'
+            $result.Phases[3].Name | Should Be 'Verify'
+            (Test-Path -Path $handshakeFile) | Should Be $true
+            (Test-Path -Path $activationFile) | Should Be $true
+            (Test-Path -Path $cleanupFile) | Should Be $true
+            (Test-Path -Path $staleFile) | Should Be $false
+        }
+        finally {
+            if (Test-Path -Path $workDir) {
+                Remove-Item -Path $workDir -Recurse -Force
+            }
+        }
+    }
+
+    It 'runs cleanup and verify after activation failure in a real run' {
+        $runId = [guid]::NewGuid().ToString('N')
+        $workDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ("session-manager-it-" + $runId)
+        New-Item -Path $workDir -ItemType Directory -Force | Out-Null
+
+        try {
+            $handshakeFile = Join-Path -Path $workDir -ChildPath 'handshake.json'
+            $cleanupFile = Join-Path -Path $workDir -ChildPath 'cleanup.log'
+
+            $manager = New-SessionManager `
+                -SessionId 'integration-activation-fail-001' `
+                -HandshakeAction {
+                    param($context, $activationRecord)
+                    $context.HandshakeData.File = $handshakeFile
+                    @{ protocol = 'drmHandshake'; status = 'ok' } | ConvertTo-Json | Set-Content -Path $handshakeFile -Encoding UTF8
+                } `
+                -ActivationAction {
+                    param($context, $activationRecord)
+                    throw 'Simulated activation outage'
+                } `
+                -CleanupAction {
+                    param($context, $activationRecord)
+                    "cleanup complete for $($context.SessionId)" | Set-Content -Path $cleanupFile -Encoding UTF8
+                    $context.CleanupDetails.Path = $cleanupFile
+                } `
+                -VerifyAction {
+                    param($context, $activationRecord)
+                    if (-not (Test-Path -Path $context.HandshakeData.File)) { throw 'Handshake artifact missing.' }
+                    if (-not (Test-Path -Path $context.CleanupDetails.Path)) { throw 'Cleanup artifact missing.' }
+                    if (-not $context.Failure) { throw 'Expected failure context not found.' }
+                    if ($context.Failure.Phase -ne 'ActivationRecord') { throw 'Failure phase was not captured as ActivationRecord.' }
+                }
+
+            $result = $manager.Run()
+
+            $result.Succeeded | Should Be $false
+            $result.Phases.Count | Should Be 4
+            $result.Phases[1].Name | Should Be 'ActivationRecord'
+            $result.Phases[1].Succeeded | Should Be $false
+            $result.Phases[1].ErrorMessage | Should Match 'Simulated activation outage'
+            $result.Phases[2].Name | Should Be 'Cleanup'
+            $result.Phases[2].Succeeded | Should Be $true
+            $result.Phases[3].Name | Should Be 'Verify'
+            $result.Phases[3].Succeeded | Should Be $true
+            (Test-Path -Path $cleanupFile) | Should Be $true
+        }
+        finally {
+            if (Test-Path -Path $workDir) {
+                Remove-Item -Path $workDir -Recurse -Force
+            }
+        }
+    }
+}

--- a/powershell/SessionManagement/tests/SessionManager.Tests.ps1
+++ b/powershell/SessionManagement/tests/SessionManager.Tests.ps1
@@ -1,0 +1,112 @@
+$moduleManifest = Join-Path -Path $PSScriptRoot -ChildPath '..\SessionManagement.psd1'
+Import-Module $moduleManifest -Force
+
+Describe 'SessionManager lifecycle' {
+    It 'runs all phases in order and succeeds on happy path' {
+        $order = [System.Collections.Generic.List[string]]::new()
+
+        $manager = New-SessionManager `
+            -SessionId 'happy-001' `
+            -HandshakeAction {
+                param($context, $activationRecord)
+                $order.Add('SessionHandshake')
+                $context.HandshakeData.Ready = $true
+            } `
+            -ActivationAction {
+                param($context, $activationRecord)
+                $order.Add('ActivationRecord')
+                $activationRecord.Status = 'Active'
+            } `
+            -CleanupAction {
+                param($context, $activationRecord)
+                $order.Add('Cleanup')
+                $context.CleanupDetails.Done = $true
+            } `
+            -VerifyAction {
+                param($context, $activationRecord)
+                $order.Add('Verify')
+                if (-not $context.HandshakeData.Ready) { throw 'Handshake not ready.' }
+                if ($activationRecord.Status -ne 'Active') { throw 'Activation missing.' }
+            }
+
+        $result = $manager.Run()
+
+        $result.Succeeded | Should Be $true
+        $result.SessionId | Should Be 'happy-001'
+        $result.Phases.Count | Should Be 4
+        $result.Phases[0].Name | Should Be 'SessionHandshake'
+        $result.Phases[1].Name | Should Be 'ActivationRecord'
+        $result.Phases[2].Name | Should Be 'Cleanup'
+        $result.Phases[3].Name | Should Be 'Verify'
+        @($order.ToArray()) | Should Be @('SessionHandshake', 'ActivationRecord', 'Cleanup', 'Verify')
+    }
+
+    It 'still runs cleanup and verify when handshake fails' {
+        $order = [System.Collections.Generic.List[string]]::new()
+
+        $manager = New-SessionManager `
+            -SessionId 'fail-handshake-001' `
+            -HandshakeAction {
+                param($context, $activationRecord)
+                $order.Add('SessionHandshake')
+                throw 'Handshake failed'
+            } `
+            -ActivationAction {
+                param($context, $activationRecord)
+                $order.Add('ActivationRecord')
+                $activationRecord.Status = 'Active'
+            } `
+            -CleanupAction {
+                param($context, $activationRecord)
+                $order.Add('Cleanup')
+                $context.CleanupDetails.Done = $true
+            } `
+            -VerifyAction {
+                param($context, $activationRecord)
+                $order.Add('Verify')
+                $context.Verification.Checked = $true
+            }
+
+        $result = $manager.Run()
+
+        $result.Succeeded | Should Be $false
+        $result.Phases.Count | Should Be 3
+        $result.Phases[0].Name | Should Be 'SessionHandshake'
+        $result.Phases[0].Succeeded | Should Be $false
+        $result.Phases[0].ErrorMessage | Should Match 'Handshake failed'
+        $result.Phases[1].Name | Should Be 'Cleanup'
+        $result.Phases[1].Succeeded | Should Be $true
+        $result.Phases[2].Name | Should Be 'Verify'
+        $result.Phases[2].Succeeded | Should Be $true
+        @($order.ToArray()) | Should Be @('SessionHandshake', 'Cleanup', 'Verify')
+    }
+
+    It 'marks overall run as failed when verify phase throws' {
+        $manager = New-SessionManager `
+            -SessionId 'fail-verify-001' `
+            -HandshakeAction {
+                param($context, $activationRecord)
+                $context.HandshakeData.Ready = $true
+            } `
+            -ActivationAction {
+                param($context, $activationRecord)
+                $activationRecord.Status = 'Active'
+            } `
+            -CleanupAction {
+                param($context, $activationRecord)
+                $context.CleanupDetails.Done = $true
+            } `
+            -VerifyAction {
+                param($context, $activationRecord)
+                throw 'Verification failed'
+            }
+
+        $result = $manager.Run()
+
+        $result.Succeeded | Should Be $false
+        $result.Phases.Count | Should Be 4
+        $result.Phases[3].Name | Should Be 'Verify'
+        $result.Phases[3].Succeeded | Should Be $false
+        $result.Phases[3].ErrorMessage | Should Match 'Verification failed'
+    }
+}


### PR DESCRIPTION
## Summary
- add a new PowerShell SessionManagement module with a class-based lifecycle runner
- implement four explicit phases: SessionHandshake, ActivationRecord, Cleanup, Verify
- add unit tests and integration tests for success and failure paths
- document module import, example usage, and test commands in README

## Validation
- Invoke-Pester -Script .\\powershell\\SessionManagement\\tests\\SessionManager.Tests.ps1
- Invoke-Pester -Script .\\powershell\\SessionManagement\\tests\\SessionManager.Integration.Tests.ps1

Co-Authored-By: Oz <oz-agent@warp.dev>