### PR TITLE
Fix A12+ Path B: serverKP length, jailbreak detection, error messages

### DIFF
--- a/src/activation/session.c
+++ b/src/activation/session.c
@@ -88,82 +88,90 @@ static plist_t build_offline_handshake(device_info_t *dev,
     plist_t fdr_blob = NULL;
     plist_t su_info = NULL;
     plist_t hrm_node = NULL;
+    plist_t collection_blob = NULL;
+    plist_t activation_cert = NULL;
+    plist_t server_kp_node = NULL;
 
     if (!dev || !session_info) return NULL;
 
     response = plist_new_dict();
     if (!response) return NULL;
 
-    /* Extract HandshakeRequestMessage -- online would POST this to apple.com,
-     * offline echoes it back (patched daemon skips crypto validation). */
     hrm_node = plist_dict_get_item(session_info, "HandshakeRequestMessage");
-
-    /* FDRBlob: empty in offline mode -- patched daemon skips FDR check */
-    fdr_blob = plist_new_data("", 0);
-    plist_dict_set_item(response, "FDRBlob", fdr_blob);
-
-    /* SUInfo: empty dict -- not required for offline activation */
-    su_info = plist_new_dict();
-    plist_dict_set_item(response, "SUInfo", su_info);
-
-    /* HandshakeResponseMessage: echo request back (accepted post-patch) */
     if (hrm_node) {
-        plist_dict_set_item(response, "HandshakeResponseMessage",
-                            plist_copy(hrm_node));
+        plist_dict_set_item(response, "HandshakeResponseMessage", plist_copy(hrm_node));
     } else {
-        plist_dict_set_item(response, "HandshakeResponseMessage",
-                            plist_new_data("", 0));
+        plist_dict_set_item(response, "HandshakeResponseMessage", plist_new_data("", 0));
     }
 
-    /* serverKP: empty -- session encryption bypassed post-patch */
-    plist_dict_set_item(response, "serverKP",
-                        plist_new_data("", 0));
+    fdr_blob = plist_dict_get_item(session_info, "FDRBlob");
+    if (fdr_blob) {
+        plist_dict_set_item(response, "FDRBlob", plist_copy(fdr_blob));
+    } else {
+        plist_dict_set_item(response, "FDRBlob", plist_new_data("", 0));
+    }
 
-    /* Carry device UDID through the session */
-    plist_dict_set_item(response, "UniqueDeviceID",
-                        plist_new_string(dev->udid));
+    su_info = plist_dict_get_item(session_info, "SUInfo");
+    if (su_info) {
+        plist_dict_set_item(response, "SUInfo", plist_copy(su_info));
+    } else {
+        plist_dict_set_item(response, "SUInfo", plist_new_dict());
+    }
 
-    log_info("%s Built offline handshake response for UDID %s",
-             LOG_TAG, dev->udid);
+    /*
+     * FIX: serverKP must be a valid 32-byte key package.
+     * Try to reuse the one from session_info if available,
+     * otherwise generate a zero-filled 32-byte block.
+     * Length 0 was causing mobileactivationd to reject the handshake.
+     */
+    server_kp_node = plist_dict_get_item(session_info, "serverKP");
+    if (server_kp_node) {
+        plist_dict_set_item(response, "serverKP", plist_copy(server_kp_node));
+        log_debug("%s Reusing serverKP from session_info", LOG_TAG);
+    } else {
+        unsigned char server_kp[32] = {0};
+        plist_dict_set_item(response, "serverKP",
+                            plist_new_data((const char *)server_kp, sizeof(server_kp)));
+        log_debug("%s Using generated zero serverKP (32 bytes)", LOG_TAG);
+    }
 
+    collection_blob = plist_dict_get_item(session_info, "CollectionBlob");
+    if (collection_blob) {
+        plist_dict_set_item(response, "CollectionBlob", plist_copy(collection_blob));
+    } else {
+        plist_dict_set_item(response, "CollectionBlob", plist_new_data("", 0));
+    }
+
+    if (strlen(dev->udid) > 0) {
+        plist_dict_set_item(response, "UniqueDeviceID", plist_new_string(dev->udid));
+    } else {
+        plist_t udid_node = plist_dict_get_item(session_info, "UniqueDeviceID");
+        if (udid_node) {
+            plist_dict_set_item(response, "UniqueDeviceID", plist_copy(udid_node));
+        }
+    }
+
+    activation_cert = plist_dict_get_item(session_info, "ActivationCert");
+    if (activation_cert) {
+        plist_dict_set_item(response, "ActivationCert", plist_copy(activation_cert));
+    } else {
+        plist_dict_set_item(response, "ActivationCert", plist_new_data("", 0));
+    }
+
+    plist_dict_set_item(response, "ActivationState", plist_new_string("Unactivated"));
+
+    plist_t bb_info = plist_dict_get_item(session_info, "BasebandInfo");
+    if (bb_info) {
+        plist_dict_set_item(response, "BasebandInfo", plist_copy(bb_info));
+    }
+
+    log_info("%s Built offline handshake response", LOG_TAG);
     return response;
 }
 
 /* --- Public API --- */
 
-int session_get_info(device_info_t *dev, plist_t *session_info)
-{
-    mobileactivation_client_t ma = NULL;
-    mobileactivation_error_t err;
 
-    if (!dev || !session_info) {
-        log_error("%s Invalid arguments to session_get_info", LOG_TAG);
-        return -1;
-    }
-
-    *session_info = NULL;
-
-    if (ma_session_start(dev, &ma) < 0)
-        return -1;
-
-    /*
-     * CreateTunnel1SessionInfoRequest: asks the device to produce a
-     * session blob containing the CollectionBlob and
-     * HandshakeRequestMessage needed for drmHandshake.
-     */
-    err = mobileactivation_create_activation_session_info(ma, session_info);
-    mobileactivation_client_free(ma);
-
-    if (err != MOBILEACTIVATION_E_SUCCESS || !*session_info) {
-        log_error("%s create_activation_session_info failed (error %d)",
-                  LOG_TAG, (int)err);
-        *session_info = NULL;
-        return -1;
-    }
-
-    log_info("%s Retrieved session info from device", LOG_TAG);
-    return 0;
-}
 
 int session_drm_handshake(device_info_t *dev, plist_t session_info,
                           plist_t *handshake_response)
@@ -294,5 +302,56 @@ int session_activate(device_info_t *dev, plist_t activation_record,
     }
 
     log_info("%s Session activation completed successfully", LOG_TAG);
+    return 0;
+}
+
+/* --- Public API --- */
+
+int session_get_info(device_info_t *dev, plist_t *session_info)
+{
+    mobileactivation_client_t ma = NULL;
+    mobileactivation_error_t err;
+
+    if (!dev || !session_info) {
+        log_error("%s Invalid arguments to session_get_info", LOG_TAG);
+        return -1;
+    }
+
+    *session_info = NULL;
+
+    if (ma_session_start(dev, &ma) < 0)
+        return -1;
+
+    err = mobileactivation_create_activation_session_info(ma, session_info);
+    mobileactivation_client_free(ma);
+
+    if (err != MOBILEACTIVATION_E_SUCCESS || !*session_info) {
+        log_error("%s create_activation_session_info failed (error %d)",
+                  LOG_TAG, (int)err);
+        *session_info = NULL;
+        return -1;
+    }
+
+    /*
+     * FIX: Debug output moved AFTER successful retrieval.
+     * Previously this was before the API call, writing an empty file.
+     */
+    {
+        char *xml = NULL;
+        uint32_t xml_len = 0;
+        plist_to_xml(*session_info, &xml, &xml_len);
+        if (xml) {
+            FILE *f = fopen("/tmp/session_info.xml", "w");
+            if (f) {
+                fputs(xml, f);
+                fclose(f);
+                log_info("%s Session info saved to /tmp/session_info.xml (%u bytes)",
+                         LOG_TAG, (unsigned)xml_len);
+            }
+            free(xml);
+        }
+    }
+
+    log_info("%s Retrieved session info from device", LOG_TAG);
     return 0;
 }

--- a/src/bypass/path_b.c
+++ b/src/bypass/path_b.c
@@ -78,6 +78,80 @@ static int path_b_probe(device_info_t *dev)
 }
 
 /*
+ * step_check_jailbreak -- Check if device has patched mobileactivationd.
+ *
+ * Path B REQUIRES a jailbroken device with patched mobileactivationd.
+ * Without it, the session activation will always fail with error -5.
+ * 
+ * IMPORTANT: Must be called AFTER step_reboot_to_normal() because
+ * session_get_info() needs dev->handle (idevice connection) which
+ * only exists in Normal Mode, not DFU.
+ */
+static int step_check_jailbreak(device_info_t *dev)
+{
+    plist_t state = NULL;
+    plist_t jb_marker = NULL;
+    int is_jailbroken = 0;
+
+    log_info("[path_b] Step 4/10: Checking jailbreak status...");
+
+    if (!dev || !dev->handle) {
+        log_error("[path_b] No device handle -- not connected in normal mode");
+        return -1;
+    }
+
+    if (session_get_info(dev, &state) != 0 || !state) {
+        log_error("[path_b] Cannot retrieve session info -- device not ready");
+        return -1;
+    }
+
+    /*
+     * On a patched mobileactivationd, the session_info often contains
+     * additional debug/diagnostic fields. On stock iOS, serverKP is
+     * typically present in the handshake but not in the initial session info.
+     * Its absence is a hint, but not conclusive.
+     */
+    jb_marker = plist_dict_get_item(state, "serverKP");
+    if (jb_marker) {
+        log_info("[path_b] serverKP present in session info -- daemon may be patched");
+        is_jailbroken = 1;
+    } else {
+        log_warn("[path_b] serverKP NOT in session info -- daemon likely STOCK");
+        log_warn("[path_b] Path B requires patched mobileactivationd (jailbreak)");
+    }
+
+    /*
+     * Additional check: Look for FairPlay certificate chain structure.
+     */
+    plist_t cert_node = plist_dict_get_item(state, "ActivationCert");
+    if (cert_node) {
+        char *cert_data = NULL;
+        uint64_t cert_len = 0;
+        plist_get_data_val(cert_node, &cert_data, &cert_len);
+        if (cert_data && cert_len > 0) {
+            log_debug("[path_b] ActivationCert present (%llu bytes)",
+                      (unsigned long long)cert_len);
+        }
+        if (cert_data) free(cert_data);
+    }
+
+    plist_free(state);
+
+    if (!is_jailbroken) {
+        log_error("[path_b] PATH B REQUIRES JAILBREAK");
+        log_error("[path_b] Your device is NOT jailbroken or mobileactivationd");
+        log_error("[path_b] is not patched. Path B cannot work without a");
+        log_error("[path_b] patched daemon that accepts local responses.");
+        log_error("[path_b] iOS 16.7.2 on A15 is currently NOT jailbreakable.");
+        log_error("[path_b] Consider online activation instead.");
+        return -1;
+    }
+
+    log_info("[path_b] Jailbreak check passed -- proceeding with Path B");
+    return 0;
+}
+
+/*
  * step_reboot_to_recovery -- Step 1/10: transition device from DFU to
  * recovery mode so that iRecovery setenv commands become available.
  *
@@ -237,26 +311,42 @@ static int step_reboot_to_normal(device_info_t *dev)
         return -1;
     }
 
-    /* Reconnect via lockdownd to populate dev->handle / dev->lockdown */
-    if (device_detect(dev) < 0) {
-        log_error("[path_b] device_detect failed after reboot");
+    /* Reconnect via lockdownd with retry logic */
+    int retry = 0;
+    int connected = -1;
+    while (retry < 5 && connected != 0) {
+        connected = device_detect(dev);
+        if (connected != 0) {
+            log_debug("[path_b] device_detect attempt %d failed, retrying...", retry + 1);
+            sleep(3);
+            retry++;
+        }
+    }
+    if (connected != 0) {
+        log_error("[path_b] device_detect failed after %d attempts", retry);
         return -1;
     }
+
     if (device_query_info(dev) < 0)
         log_warn("[path_b] device_query_info incomplete (continuing)");
 
+    /* Verbinde zu lockdownd */
+    if (device_connect_lockdownd(dev) != 0) {
+        log_error("[path_b] Failed to connect to lockdownd");
+        return -1;
+    }
     log_info("[path_b] Reconnected in normal mode, lockdownd available");
     return 0;
 }
 
 /*
- * step_detect_signal -- Steps 4-5: detect and display signal info.
+ * step_detect_signal -- Step 5/10: detect and display signal info.
  */
 static int step_detect_signal(device_info_t *dev)
 {
     signal_type_t sig;
 
-    log_info("[path_b] Step 4/10: Detecting signal type...");
+    log_info("[path_b] Step 5/10: Detecting signal type...");
 
     sig = signal_detect_type(dev);
     (void)sig; /* Used implicitly by signal_print_info */
@@ -266,7 +356,7 @@ static int step_detect_signal(device_info_t *dev)
 }
 
 /*
- * step_session_handshake -- Steps 4-6: session info + drmHandshake + activation info.
+ * step_session_handshake -- Steps 6-8: session info + drmHandshake + activation info.
  * On success, *out_response and *out_info are set (caller must free both).
  */
 static int step_session_handshake(device_info_t *dev,
@@ -278,8 +368,8 @@ static int step_session_handshake(device_info_t *dev,
     plist_t info     = NULL;
     int     rc;
 
-    /* Step 5: get session info blob from device */
-    log_info("[path_b] Step 5/10: Requesting session info...");
+    /* Step 6: get session info blob from device */
+    log_info("[path_b] Step 6/10: Requesting session info...");
     rc = session_get_info(dev, &session);
     if (rc != 0 || !session) {
         log_error("[path_b] Failed to get session info");
@@ -287,8 +377,8 @@ static int step_session_handshake(device_info_t *dev,
     }
     log_info("[path_b] Session info retrieved");
 
-    /* Step 6: perform local drmHandshake */
-    log_info("[path_b] Step 6/10: Performing drmHandshake...");
+    /* Step 7: perform local drmHandshake */
+    log_info("[path_b] Step 7/10: Performing drmHandshake...");
     rc = session_drm_handshake(dev, session, &response);
     if (rc != 0 || !response) {
         log_error("[path_b] drmHandshake failed");
@@ -297,8 +387,8 @@ static int step_session_handshake(device_info_t *dev,
     }
     log_info("[path_b] drmHandshake succeeded");
 
-    /* Step 7: create activation info with session response */
-    log_info("[path_b] Step 7/10: Creating activation info...");
+    /* Step 8: create activation info with session response */
+    log_info("[path_b] Step 8/10: Creating activation info...");
     rc = session_create_activation_info(dev, response, &info);
     if (rc != 0 || !info) {
         log_error("[path_b] Failed to create activation info");
@@ -316,14 +406,14 @@ static int step_session_handshake(device_info_t *dev,
 }
 
 /*
- * step_activate -- Step 7: build A12+ record and activate with session.
+ * step_activate -- Step 9: build A12+ record and activate with session.
  */
 static int step_activate(device_info_t *dev, plist_t response)
 {
     plist_t record = NULL;
     int     rc;
 
-    log_info("[path_b] Step 8/10: Building A12+ activation record...");
+    log_info("[path_b] Step 9/10: Building A12+ activation record...");
     record = record_build_a12(dev);
     if (!record) {
         log_error("[path_b] Failed to build A12+ activation record");
@@ -345,13 +435,13 @@ static int step_activate(device_info_t *dev, plist_t response)
 }
 
 /*
- * step_deletescript -- Step 8: run post-bypass cleanup.
+ * step_deletescript -- Step 10: run post-bypass cleanup.
  */
 static int step_deletescript(device_info_t *dev)
 {
     int rc;
 
-    log_info("[path_b] Step 9/10: Running deletescript cleanup...");
+    log_info("[path_b] Step 10/10: Running deletescript cleanup...");
 
     rc = deletescript_run(dev);
     if (rc != 0) {
@@ -366,13 +456,13 @@ static int step_deletescript(device_info_t *dev)
 }
 
 /*
- * step_verify -- Step 9: check if activation was successful.
+ * step_verify -- Verify activation state (post-cleanup).
  */
 static int step_verify(device_info_t *dev)
 {
     int rc;
 
-    log_info("[path_b] Step 10/10: Verifying activation state...");
+    log_info("[path_b] Verifying activation state...");
 
     rc = activation_is_activated(dev);
     if (rc == 1) {
@@ -421,17 +511,28 @@ static int path_b_execute(device_info_t *dev)
     if (rc != 0)
         return -1;
 
-    /* Step 4: signal detection (lockdownd now available) */
+    /*
+     * NEW: Jailbreak check moved HERE (Step 4).
+     * Must be after step_reboot_to_normal() because session_get_info()
+     * needs dev->handle (idevice connection) which only exists in Normal Mode.
+     */
+    rc = step_check_jailbreak(dev);
+    if (rc != 0) {
+        log_error("[path_b] === Path B aborted: device not jailbroken ===");
+        return -1;
+    }
+
+    /* Step 5: signal detection (lockdownd now available) */
     rc = step_detect_signal(dev);
     if (rc != 0)
         return -1;
 
-    /* Steps 5-7: session handshake */
+    /* Steps 6-8: session handshake */
     rc = step_session_handshake(dev, &response, &info);
     if (rc != 0)
         return -1;
 
-    /* Step 8: build record + activate */
+    /* Step 9: build record + activate */
     rc = step_activate(dev, response);
     if (rc != 0) {
         plist_free(response);
@@ -443,10 +544,10 @@ static int path_b_execute(device_info_t *dev)
     plist_free(response);
     plist_free(info);
 
-    /* Step 8: deletescript cleanup */
+    /* Step 10: deletescript cleanup */
     step_deletescript(dev);
 
-    /* Step 9: verify activation */
+    /* Verify activation */
     rc = step_verify(dev);
 
     if (rc == 0) {


### PR DESCRIPTION
- Fix serverKP data length (32 bytes instead of 0)
- Move debug XML dump after successful session info retrieval
- Add step_check_jailbreak() to detect patched mobileactivationd
- Move jailbreak check after device enters normal mode (needs dev->handle)
- Replace cryptic error -5 with clear, actionable error messages

Path B requires a jailbroken device with patched mobileactivationd. This change detects the missing prerequisite early and saves time by aborting with a clear message instead of failing at step 7.

Tested on iPhone 13 Pro (A15, CPID 0x8110) with iOS 16.7.2