### PR TITLE
diagnostics: add tr4mpass doctor subcommand + typed error taxonomy

### DIFF
--- a/include/cli/doctor.h
+++ b/include/cli/doctor.h
@@ -1,0 +1,30 @@
+#ifndef TR4MPASS_CLI_DOCTOR_H
+#define TR4MPASS_CLI_DOCTOR_H
+
+/*
+ * doctor.h -- `tr4mpass doctor` preflight diagnostic subcommand (T10).
+ *
+ * Runs a dependency-light environment report covering: pkg-config
+ * presence/version for the 7 libraries tr4mpass links against,
+ * libplist/libirecovery compat-shim status (see include/compat/),
+ * the build-time probe results recorded in .build-flags, usbmuxd
+ * state, USB visibility of Apple (05ac) devices, WSL detection, and
+ * a binary-shadowing check (./tr4mpass must be a regular file, not a
+ * directory).
+ *
+ * Callable standalone before any USB/device init runs -- `main()`
+ * dispatches to it directly when argv[1] == "doctor", bypassing the
+ * rest of the normal startup path entirely.
+ */
+
+/*
+ * Run the full preflight report and print it to stdout. When
+ * `verbose` is non-zero, print additional detail (e.g. every
+ * .build-flags entry) under checks that support it.
+ *
+ * Returns 0 if every check passed or only produced warnings, 1 if at
+ * least one check hard-failed. Never exits the process itself.
+ */
+int doctor_run(int verbose);
+
+#endif /* TR4MPASS_CLI_DOCTOR_H */

--- a/include/util/errors.h
+++ b/include/util/errors.h
@@ -1,0 +1,53 @@
+#ifndef TR4MPASS_ERRORS_H
+#define TR4MPASS_ERRORS_H
+
+/*
+ * errors.h -- typed error taxonomy for tr4mpass (T10).
+ *
+ * The tool's #1 UX failure historically was the silent bailout: a
+ * bare `return -1` with no category and no next-step, surfaced (if at
+ * all) as an unhelpful "[-] Bypass failed (error -1)". err_ctx()
+ * gives every failure path a category, a one-line diagnostic, and a
+ * one-line next step, and always points the user at `tr4mpass doctor`
+ * for the full environment report.
+ *
+ * Scope note: the codebase has on the order of ~250 bare `return -1`
+ * / log_error() sites; migrating all of them to err_ctx() is tracked
+ * as follow-up work and out of scope for this pass -- src/main.c's
+ * own error returns (detect_device(), print_module_diagnostics(), and
+ * the final bypass-failed line) have been migrated here as the
+ * flagship example of the new pattern.
+ */
+
+typedef enum {
+    ERR_ENV = 0,          /* missing/broken environment (deps, usbmuxd, WSL, ...) */
+    ERR_BUILD_DRIFT,      /* library API drift the compat shims did not cover */
+    ERR_DEVICE_UNSEEN,    /* no device visible on any known USB interface */
+    ERR_DFU_MODE,         /* device not in the required DFU mode */
+    ERR_CPID_UNPARSED,    /* CPID could not be parsed from the DFU descriptor */
+    ERR_CHIP_UNSUPPORTED, /* CPID parsed but not in the chip database / no module */
+    ERR_EXPLOIT_FAILED,   /* a bypass module ran and failed */
+    ERR_SERVER_ACTIVATION /* the Albert/session-activation flow failed */
+} tr4_err_t;
+
+/*
+ * Log a categorized, actionable error via the existing log_error()
+ * and return -1, so call sites can simply `return err_ctx(...)`.
+ *
+ * Prints (through log_error(), which adds its own "[ERROR]" tag and
+ * color):
+ *
+ *   [-] <category>: <diagnostic>. Next: <next_step>.
+ *   (See `tr4mpass doctor` for full environment report.)
+ *
+ * `diagnostic` and `next_step` may be NULL; a generic placeholder is
+ * substituted so the format string never prints "(null)".
+ */
+int err_ctx(tr4_err_t category, const char *diagnostic, const char *next_step);
+
+/* Short, stable category string for a tr4_err_t, e.g.
+ * ERR_DFU_MODE -> "dfu-mode". Used by err_ctx() and safe to call
+ * directly wherever a category label is needed without logging. */
+const char *err_category_str(tr4_err_t category);
+
+#endif /* TR4MPASS_ERRORS_H */

--- a/src/cli/doctor.c
+++ b/src/cli/doctor.c
@@ -1,0 +1,325 @@
+/*
+ * doctor.c -- `tr4mpass doctor` preflight diagnostic subcommand (T10).
+ *
+ * Dependency-light: the only external processes this shells out to
+ * are `pkg-config`, `command -v lsusb`, `lsusb`, and `pgrep` -- all
+ * fixed, argv-safe command strings with no user input threaded into
+ * them. Every popen() here is deliberately a compile-time string
+ * literal for that reason.
+ */
+
+#include "cli/doctor.h"
+#include "compat/plist_compat.h"
+#include "compat/libirecovery_compat.h"
+
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+typedef enum { CHK_OK, CHK_WARN, CHK_FAIL } chk_status_t;
+
+static int g_warn_count;
+static int g_fail_count;
+
+/* ------------------------------------------------------------------ */
+/* Report line + shell-out helper                                     */
+/* ------------------------------------------------------------------ */
+
+static void report(chk_status_t status, const char *fmt, ...)
+{
+    const char *tag;
+
+    switch (status) {
+    case CHK_WARN: tag = "[WARN]"; g_warn_count++; break;
+    case CHK_FAIL: tag = "[FAIL]"; g_fail_count++; break;
+    case CHK_OK:
+    default:       tag = "[OK]  "; break;
+    }
+
+    printf("  %s ", tag);
+    {
+        va_list ap;
+        va_start(ap, fmt);
+        vprintf(fmt, ap);
+        va_end(ap);
+    }
+    printf("\n");
+}
+
+/*
+ * Run a fixed shell command via popen(), capture its first line of
+ * stdout (trimmed) into `out` (may be NULL/0 to discard output), and
+ * return the command's exit status (-1 if popen/pclose itself
+ * failed).
+ */
+static int run_capture(const char *cmd, char *out, size_t outsz)
+{
+    if (out && outsz)
+        out[0] = '\0';
+
+    FILE *fp = popen(cmd, "r"); /* NOLINT: cmd is always a fixed literal */
+    if (!fp)
+        return -1;
+
+    if (out && outsz && fgets(out, (int)outsz, fp) != NULL) {
+        size_t len = strlen(out);
+        while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r'))
+            out[--len] = '\0';
+    }
+
+    int rc = pclose(fp);
+    if (rc == -1)
+        return -1;
+#ifdef WIFEXITED
+    if (WIFEXITED(rc))
+        return WEXITSTATUS(rc);
+    return -1;
+#else
+    return rc;
+#endif
+}
+
+/* ------------------------------------------------------------------ */
+/* Individual checks                                                  */
+/* ------------------------------------------------------------------ */
+
+/* Kept in sync with the authoritative pkg-config list in Makefile
+ * (PKG_LIBS) and start.sh (PKGCONFIG_DEPS) -- unified there under T1. */
+static const char *const g_pkg_libs[] = {
+    "libimobiledevice-1.0",
+    "libirecovery-1.0",
+    "libusb-1.0",
+    "libplist-2.0",
+    "openssl",
+    "libcurl",
+    "libssh2",
+};
+#define NUM_PKG_LIBS (sizeof(g_pkg_libs) / sizeof(g_pkg_libs[0]))
+
+static void check_pkgconfig(void)
+{
+    printf("\n-- pkg-config dependencies --\n");
+    for (size_t i = 0; i < NUM_PKG_LIBS; i++) {
+        char cmd[128];
+        char version[64];
+
+        snprintf(cmd, sizeof(cmd), "pkg-config --modversion %s 2>/dev/null",
+                  g_pkg_libs[i]);
+        int rc = run_capture(cmd, version, sizeof(version));
+        if (rc == 0 && version[0])
+            report(CHK_OK, "%-24s version %s", g_pkg_libs[i], version);
+        else
+            report(CHK_FAIL, "%-24s not found by pkg-config", g_pkg_libs[i]);
+    }
+}
+
+static void check_libplist_compat(void)
+{
+    printf("\n-- libplist compat shim (include/compat/plist_compat.h) --\n");
+#ifdef TP_PLIST_HAS_MEM_FREE
+    report(CHK_OK, "plist_mem_free() available (libplist >= 2.3)");
+#else
+    report(CHK_WARN,
+           "plist_mem_free() not available; using free() fallback (libplist < 2.3)");
+#endif
+#ifdef TP_PLIST_HAS_FMT_ARG
+    report(CHK_OK, "plist_from_memory() 4-arg form available (libplist >= 2.3)");
+#else
+    report(CHK_WARN,
+           "plist_from_memory() 4-arg form not available; using 3-arg fallback (libplist < 2.3)");
+#endif
+}
+
+static void check_libirecovery_compat(void)
+{
+    printf("\n-- libirecovery compat shim (include/compat/libirecovery_compat.h) --\n");
+#if TP_IRECV_NEEDS_MANUAL_ZLP
+    report(CHK_WARN,
+           "IRECV_SEND_OPT_DFU_NOTIFY_FINISH not available; manual zero-length-packet fallback in use");
+#else
+    report(CHK_OK, "IRECV_SEND_OPT_DFU_NOTIFY_FINISH available");
+#endif
+}
+
+/* .build-flags is written by `make` (see Makefile's .build-flags
+ * target) with the same three probe results baked into the compat
+ * headers above -- shown here for cross-verification against what
+ * this particular binary was actually compiled with. */
+static void check_build_flags(int verbose)
+{
+    printf("\n-- build-time probe flags (.build-flags) --\n");
+
+    FILE *fp = fopen(".build-flags", "r");
+    if (!fp) {
+        report(CHK_WARN,
+               ".build-flags not found in the current directory -- run from the repo root after `make` to cross-check probe results");
+        return;
+    }
+
+    char line[128];
+    int count = 0;
+    while (fgets(line, sizeof(line), fp)) {
+        size_t len = strlen(line);
+        while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r'))
+            line[--len] = '\0';
+        if (line[0] == '\0')
+            continue;
+        count++;
+        if (verbose)
+            report(CHK_OK, "%s", line);
+    }
+    fclose(fp);
+
+    if (!verbose)
+        report(CHK_OK, "%d probe result(s) recorded (pass -v for details)", count);
+}
+
+static void check_usbmuxd(void)
+{
+    printf("\n-- usbmuxd --\n");
+
+    /* pgrep -x is the same test used by start-helpers.sh's hints
+     * (systemctl status usbmuxd) -- portable to macOS and Linux. */
+    int rc = run_capture("pgrep -x usbmuxd 2>/dev/null", NULL, 0);
+    if (rc == 0) {
+        report(CHK_OK, "usbmuxd process is running");
+        return;
+    }
+
+    struct stat st;
+    if (stat("/var/run/usbmuxd", &st) == 0) {
+        report(CHK_OK, "usbmuxd socket present at /var/run/usbmuxd");
+        return;
+    }
+
+    report(CHK_WARN,
+           "usbmuxd not detected (no process, no /var/run/usbmuxd socket) -- normal-mode device queries will fail; "
+           "start it (Linux: sudo systemctl start usbmuxd)");
+}
+
+static void check_usb_visibility(void)
+{
+    printf("\n-- USB visibility (Apple vendor 05ac) --\n");
+
+    char path[256];
+    int rc = run_capture("command -v lsusb 2>/dev/null", path, sizeof(path));
+    if (rc != 0 || path[0] == '\0') {
+        report(CHK_WARN,
+               "lsusb not available on this platform (expected on macOS) -- skipping USB visibility check");
+        return;
+    }
+
+    char out[64];
+    run_capture("lsusb 2>/dev/null | grep -ci '05ac:'", out, sizeof(out));
+    int count = out[0] ? atoi(out) : 0;
+
+    if (count > 0)
+        report(CHK_OK, "%d Apple (05ac) USB device(s) visible via lsusb", count);
+    else
+        report(CHK_WARN,
+               "No Apple (05ac) USB device visible via lsusb -- connect the device (and its cable/port) or enter DFU mode");
+}
+
+static void check_wsl(void)
+{
+    printf("\n-- WSL / environment --\n");
+
+    const char *distro = getenv("WSL_DISTRO_NAME");
+    int is_wsl = (distro && *distro) ? 1 : 0;
+
+    FILE *fp = fopen("/proc/version", "r");
+    if (fp) {
+        char buf[512];
+        if (fgets(buf, sizeof(buf), fp)) {
+            for (char *p = buf; *p; p++)
+                *p = (char)tolower((unsigned char)*p);
+            if (strstr(buf, "microsoft") || strstr(buf, "wsl"))
+                is_wsl = 1;
+        }
+        fclose(fp);
+    }
+
+    if (!is_wsl) {
+        report(CHK_OK, "Not running under WSL");
+        return;
+    }
+
+    report(CHK_WARN,
+           "Running under WSL%s%s -- USB devices need usbipd-win passthrough (`usbipd attach --wsl --busid <id>`)",
+           (distro && *distro) ? ": " : "", (distro && *distro) ? distro : "");
+
+    char cwd[1024];
+    if (getcwd(cwd, sizeof(cwd)) &&
+        (strncmp(cwd, "/mnt/c", 6) == 0 || strncmp(cwd, "/mnt/d", 6) == 0)) {
+        report(CHK_FAIL,
+               "Checked out on a Windows-mounted path (%s) -- clone into your Linux home instead (e.g. ~/tr4mpass) for working USB passthrough and I/O performance",
+               cwd);
+    }
+}
+
+static void check_binary_shadow(void)
+{
+    printf("\n-- binary shadowing --\n");
+
+    struct stat st;
+    if (stat("./tr4mpass", &st) != 0) {
+        report(CHK_WARN,
+               "./tr4mpass not found in the current directory -- run doctor from the repo root after `make`, or ignore this if invoked as `tr4mpass doctor` from PATH");
+        return;
+    }
+
+    if (S_ISDIR(st.st_mode)) {
+        report(CHK_FAIL,
+               "./tr4mpass exists but is a DIRECTORY, not the binary -- remove it and rebuild: rm -rf ./tr4mpass && make clean && make");
+        return;
+    }
+
+    if (!S_ISREG(st.st_mode)) {
+        report(CHK_WARN, "./tr4mpass exists but is not a regular file (mode 0%o)",
+               (unsigned)(st.st_mode & 07777u));
+        return;
+    }
+
+    report(CHK_OK, "./tr4mpass is a regular file");
+}
+
+/* ------------------------------------------------------------------ */
+/* Entry point                                                        */
+/* ------------------------------------------------------------------ */
+
+int doctor_run(int verbose)
+{
+    g_warn_count = 0;
+    g_fail_count = 0;
+
+    printf("========================================\n"
+           "  tr4mpass doctor -- environment preflight\n"
+           "========================================\n");
+
+    check_pkgconfig();
+    check_libplist_compat();
+    check_libirecovery_compat();
+    check_build_flags(verbose);
+    check_usbmuxd();
+    check_usb_visibility();
+    check_wsl();
+    check_binary_shadow();
+
+    printf("\n========================================\n");
+    if (g_fail_count > 0)
+        printf("  Summary: %d FAIL, %d WARN -- fix the FAIL item(s) above before running tr4mpass.\n",
+               g_fail_count, g_warn_count);
+    else if (g_warn_count > 0)
+        printf("  Summary: 0 FAIL, %d WARN -- tr4mpass should run, but review the warning(s) above.\n",
+               g_warn_count);
+    else
+        printf("  Summary: all checks passed.\n");
+    printf("========================================\n");
+
+    return (g_fail_count > 0) ? 1 : 0;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,9 @@
 #include "activation/activation.h"
 #include "util/log.h"
 #include "util/env_config.h"
+#include "util/errors.h"
 #include "cli/cli_flags.h"
+#include "cli/doctor.h"
 
 typedef struct {
     int verbose;
@@ -43,7 +45,8 @@ static void print_banner(void)
 
 static void print_usage(const char *prog)
 {
-    printf("Usage: %s [OPTIONS]\n\n"
+    printf("Usage: %s [OPTIONS]\n"
+           "       %s doctor [-v]      Run environment preflight diagnostics and exit\n\n"
            "Options:\n"
            "  -v, --verbose          Enable debug logging + env summary\n"
            "  -n, --dry-run          Show what would run, do not execute\n"
@@ -55,7 +58,7 @@ static void print_usage(const char *prog)
            "      --cpid <hex>       Override CPID (e.g. --cpid 0x8960)\n"
            "      --ecid <hex>       Override ECID (e.g. --ecid 0x1F70CB1331C)\n"
            "  -h, --help             Show this help message\n\n",
-           prog);
+           prog, prog);
     cli_flags_print_help();
 }
 
@@ -153,8 +156,9 @@ static int detect_device(device_info_t *dev)
 
     log_info("No DFU device found, trying normal mode...");
     if (device_detect(dev) < 0) {
-        log_error("No device detected. Is it connected via USB?");
-        return -1;
+        return err_ctx(ERR_DEVICE_UNSEEN,
+                        "No device detected on any known USB interface",
+                        "Check the USB cable/port and that the device is powered on, then run `tr4mpass doctor` to verify usbmuxd and USB visibility");
     }
     if (device_query_info(dev) < 0)
         log_warn("Incomplete device info (partial data may be available)");
@@ -192,19 +196,28 @@ static void register_modules(void)
 
 static void print_module_diagnostics(const device_info_t *dev)
 {
-    log_error("No compatible bypass module for this device");
-    log_error("  DFU=%s CPID=0x%04X Chip=%s checkm8=%s Product=%s",
-              dev->is_dfu_mode ? "YES" : "NO", dev->cpid,
-              dev->chip_name[0] ? dev->chip_name : "(unknown)",
-              dev->checkm8_vulnerable ? "YES" : "NO",
-              dev->product_type[0] ? dev->product_type : "(unknown)");
+    char diag[256];
 
-    if (!dev->is_dfu_mode)
-        log_error("Both paths require DFU mode. Use ./start.sh or enter DFU manually.");
-    else if (dev->cpid == 0)
-        log_error("CPID is 0x0000 -- try --cpid to set manually.");
-    else if (dev->chip_name[0] == '\0' || strcmp(dev->chip_name, "Unknown") == 0)
-        log_error("Chip CPID 0x%04X not in database.", dev->cpid);
+    snprintf(diag, sizeof(diag),
+             "No compatible bypass module (DFU=%s CPID=0x%04X Chip=%s checkm8=%s Product=%s)",
+             dev->is_dfu_mode ? "YES" : "NO", dev->cpid,
+             dev->chip_name[0] ? dev->chip_name : "(unknown)",
+             dev->checkm8_vulnerable ? "YES" : "NO",
+             dev->product_type[0] ? dev->product_type : "(unknown)");
+
+    if (!dev->is_dfu_mode) {
+        err_ctx(ERR_DFU_MODE, diag,
+                "Both paths require DFU mode -- use ./start.sh or enter DFU manually");
+    } else if (dev->cpid == 0) {
+        err_ctx(ERR_CPID_UNPARSED, diag,
+                "CPID is 0x0000 -- try --cpid to set it manually");
+    } else if (dev->chip_name[0] == '\0' || strcmp(dev->chip_name, "Unknown") == 0) {
+        err_ctx(ERR_CHIP_UNSUPPORTED, diag,
+                "Chip not found in the chip database");
+    } else {
+        err_ctx(ERR_CHIP_UNSUPPORTED, diag,
+                "No registered bypass module matched this device");
+    }
 }
 
 static const bypass_module_t *select_module(device_info_t *dev,
@@ -233,6 +246,21 @@ int main(int argc, char *argv[])
     cli_opts_t opts;
     device_info_t dev;
     int ret;
+
+    /*
+     * `tr4mpass doctor` is a standalone preflight report -- it needs
+     * no USB init, no device detect, and no getopt parsing of the
+     * normal bypass-pipeline flags. Dispatch to it before anything
+     * else in main() runs.
+     */
+    if (argc >= 2 && strcmp(argv[1], "doctor") == 0) {
+        int doctor_verbose = 0;
+        for (int i = 2; i < argc; i++) {
+            if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0)
+                doctor_verbose = 1;
+        }
+        return doctor_run(doctor_verbose);
+    }
 
     print_banner();
 
@@ -381,10 +409,15 @@ ao_done:
 
     log_info("Executing module: %s", mod->name);
     ret = bypass_execute(mod, &dev);
-    if (ret == 0)
+    if (ret == 0) {
         printf("\n[+] Bypass completed successfully.\n");
-    else
-        printf("\n[-] Bypass failed (error %d).\n", ret);
+    } else {
+        char diag[128];
+        snprintf(diag, sizeof(diag), "Bypass module '%s' failed (error %d)",
+                 mod->name, ret);
+        err_ctx(ERR_EXPLOIT_FAILED, diag,
+                "Re-check DFU mode and cable/port, or retry with --force-path-a/--force-path-b or --cpid/--ecid overrides");
+    }
 
     cleanup(&dev);
     return (ret == 0) ? 0 : 1;

--- a/src/util/errors.c
+++ b/src/util/errors.c
@@ -1,0 +1,34 @@
+/*
+ * errors.c -- typed error taxonomy for tr4mpass (T10).
+ *
+ * See include/util/errors.h for the scope note on the ~250 remaining
+ * bare `return -1` sites this pass did not migrate.
+ */
+
+#include "util/errors.h"
+#include "util/log.h"
+
+const char *err_category_str(tr4_err_t category)
+{
+    switch (category) {
+    case ERR_ENV:               return "env";
+    case ERR_BUILD_DRIFT:       return "build-drift";
+    case ERR_DEVICE_UNSEEN:     return "device-unseen";
+    case ERR_DFU_MODE:          return "dfu-mode";
+    case ERR_CPID_UNPARSED:     return "cpid-unparsed";
+    case ERR_CHIP_UNSUPPORTED:  return "chip-unsupported";
+    case ERR_EXPLOIT_FAILED:    return "exploit-failed";
+    case ERR_SERVER_ACTIVATION: return "server-activation";
+    default:                    return "unknown";
+    }
+}
+
+int err_ctx(tr4_err_t category, const char *diagnostic, const char *next_step)
+{
+    log_error("[-] %s: %s. Next: %s. "
+              "(See `tr4mpass doctor` for full environment report.)",
+              err_category_str(category),
+              (diagnostic && *diagnostic) ? diagnostic : "no further detail available",
+              (next_step && *next_step) ? next_step : "run `tr4mpass doctor`");
+    return -1;
+}

--- a/start-helpers.sh
+++ b/start-helpers.sh
@@ -29,6 +29,88 @@ print_banner() {
 }
 
 # ------------------------------------------------------------------ #
+# WSL / environment preflight (T8)                                    #
+#                                                                      #
+# Runs before dependency install / build so WSL's biggest gotchas --  #
+# a Windows-mounted checkout and missing USB passthrough -- surface   #
+# immediately instead of after a multi-minute apt/build cycle.        #
+# WSL detection here is intentionally independent of detect_os()      #
+# (which runs after this) so the checks stay self-contained.          #
+# ------------------------------------------------------------------ #
+
+preflight_is_wsl() {
+    if [ -n "${WSL_DISTRO_NAME:-}" ]; then
+        return 0
+    fi
+    if grep -qiE "microsoft|wsl" /proc/version 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+preflight_environment() {
+    if ! preflight_is_wsl; then
+        return 0
+    fi
+
+    msg_ok "Preflight: WSL detected (${WSL_DISTRO_NAME:-unknown distro})"
+
+    # Refuse to run from a Windows-mounted path (/mnt/c, /mnt/d, ...).
+    # USB passthrough and I/O both suffer badly across the 9p mount,
+    # and DFU-mode transfers are timing sensitive -- this is the single
+    # largest source of "it never works" reports from WSL users.
+    case "$SCRIPT_DIR" in
+        /mnt/[a-zA-Z]/*)
+            msg_err "This repo is checked out on a Windows-mounted path: $SCRIPT_DIR"
+            msg_info "WSL's /mnt/<drive> filesystem breaks USB passthrough performance and can"
+            msg_info "corrupt timing-sensitive DFU transfers. Clone into your Linux home instead:"
+            msg_info "  cd ~ && git clone <this-repo-url> tr4mpass && cd tr4mpass && ./start.sh"
+            exit 1
+            ;;
+    esac
+
+    # Best-effort Apple-device visibility + usbipd hint. Never fail
+    # hard here -- usbipd may simply not be installed yet, or the user
+    # has not connected the device.
+    if ! command -v lsusb >/dev/null 2>&1; then
+        msg_warn "Preflight: lsusb not found -- cannot check USB visibility yet."
+        return 0
+    fi
+
+    if lsusb 2>/dev/null | grep -qi "05ac"; then
+        msg_ok "Preflight: Apple USB device already visible via lsusb."
+        return 0
+    fi
+
+    msg_warn "Preflight: no Apple USB device visible yet."
+
+    # Best-effort only: `usbipd list` should return almost instantly on
+    # real usbipd-win, but some Linux boxes have an unrelated native
+    # `usbipd` binary (usbip-utils server) with a different CLI that can
+    # block waiting on a socket -- always bound by `timeout` so this
+    # preflight can never hang the whole script.
+    local busid="" usbipd_timeout="timeout 3"
+    command -v timeout >/dev/null 2>&1 || usbipd_timeout=""
+    if command -v usbipd.exe >/dev/null 2>&1; then
+        busid="$($usbipd_timeout usbipd.exe list 2>/dev/null | grep -i "apple" | awk '{print $1}' | head -n1 || true)"
+    elif command -v usbipd >/dev/null 2>&1; then
+        busid="$($usbipd_timeout usbipd list 2>/dev/null | grep -i "apple" | awk '{print $1}' | head -n1 || true)"
+    fi
+
+    echo ""
+    echo "  In Windows PowerShell (Admin), pass the device through with usbipd:"
+    if [ -n "$busid" ]; then
+        echo "    usbipd attach --wsl --busid $busid"
+    else
+        echo "    usbipd list                       # find your device's BUSID"
+        echo "    usbipd bind --busid <BUSID>"
+        echo "    usbipd attach --wsl --busid <BUSID>"
+    fi
+    echo "  Install usbipd if missing: winget install usbipd"
+    echo ""
+}
+
+# ------------------------------------------------------------------ #
 # OS detection                                                        #
 # ------------------------------------------------------------------ #
 

--- a/start.sh
+++ b/start.sh
@@ -61,6 +61,7 @@ fi
 
 main() {
     print_banner
+    preflight_environment
     detect_os
     install_deps
     build_project


### PR DESCRIPTION
## Summary

Phase 3 ("Diagnostics UX") of the hw-usability sweep described in `research/fix-issues-hw-usability.md` -- turns silent bailouts into diagnosed failures with a next step.

- **`tr4mpass doctor`** (`src/cli/doctor.c`): standalone preflight report -- pkg-config presence/versions for the 7 build deps, libplist/libirecovery compat-shim status (reuses the Phase-1 `include/compat/*` headers), usbmuxd process/socket check, Apple (05ac) USB visibility via `lsusb`, WSL detection, and a binary-shadowing check (`./tr4mpass` regular file vs directory -- a real reported bug). Categorized `[OK]/[WARN]/[FAIL]` output with a summary line.
- **Typed error taxonomy** (`src/util/errors.c`): `ERR_ENV`, `ERR_BUILD_DRIFT`, `ERR_DEVICE_UNSEEN`, `ERR_DFU_MODE`, `ERR_CPID_UNPARSED`, `ERR_CHIP_UNSUPPORTED`, `ERR_EXPLOIT_FAILED`, `ERR_SERVER_ACTIVATION` + `err_ctx()`, which logs `[-] <category>: <diagnostic>. Next: <step>. (See tr4mpass doctor...)`. `src/main.c`'s own error returns (`detect_device()`, `print_module_diagnostics()`, the final `[-] Bypass failed` line) are migrated as the flagship example.
- **`start.sh` / `start-helpers.sh`**: new WSL/environment preflight -- refuses to run from `/mnt/c/` etc with a pointer to clone into the Linux home instead, and prints a best-effort `usbipd attach --wsl` hint (with `timeout` guards so a stray local `usbipd` binary can't hang the script) when no Apple device is visible under WSL.

## Scope notes

- Phase 2 remaining items (T6 DFU->recovery re-enum rewrite, T7 checkm8 stage-reset reorder) are **not** touched -- those need real-hardware verification and are tracked as separate follow-up.
- The full ~250-call-site `return -1` -> `err_ctx()` migration across the rest of the codebase is **not** attempted here; `main.c`'s sites are the demonstrated pattern, noted as follow-up in `errors.h`'s doc comment.
- Phase 4/5 (README rewrite, interactive decision tree, Path B SET_DESCRIPTOR removal) are separate, not part of this PR.

## Test plan

- [x] `make clean && make` -- succeeds, no new warnings
- [x] `./tr4mpass doctor` / `./tr4mpass doctor -v` -- runs standalone, no crash, sane `[OK]/[WARN]` report
- [x] `make test` -- 58/58 pass
- [x] `bash -n start.sh start-helpers.sh` -- parses clean
- [x] Manually exercised `preflight_environment()` for all three branches (non-WSL passthrough, WSL-with-no-device usbipd hint, `/mnt/c` refusal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)